### PR TITLE
move the entire line, possibly including comments

### DIFF
--- a/R/packup.R
+++ b/R/packup.R
@@ -20,7 +20,7 @@ packup <- function(){
     else{
         insertion_target <- rstudioapi::document_position(0,0)
     }
-    lib_matches <- regexec(pattern = "^\\s*library\\(\"*[a-zA-Z0-9]+\\\"*)", text = doc$contents)
+    lib_matches <- regexec(pattern = "^\\s*library\\(\"*[a-zA-Z0-9]+\\\"*).*", text = doc$contents)
     line_matches <- which(unlist(lib_matches) == 1)
     line_lengths <- unlist(lapply(lib_matches[line_matches], attr, "match.length"))
     replace_location_starts <- mapply(rstudioapi::document_position, line_matches, 1, SIMPLIFY = FALSE)


### PR DESCRIPTION
I gave this package a go (love it) and noticed it went wonky when I had a comment after my library call, which got orphaned. This PR allows the entire line to be collected and moved, so

````
# do the things
x <- y + z
library(package)
x <- r + s

# more code
library(anotherPkg) # used for cool things
l <- m + n
````

ends up as

````
library(anotherPkg) # used for cool things
library(package)
# do the things
x <- y + z

x <- r + s

# more code

l <- m + n
````